### PR TITLE
Logica API data_cleaning/main.py

### DIFF
--- a/src/backend/microservices/data_cleaning/main.py
+++ b/src/backend/microservices/data_cleaning/main.py
@@ -1,14 +1,47 @@
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Depends, status, HTTPException
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 import pyarrow as pa
 import pandas as pd
+from typing import Optional
+from data_cleaning_functions import data_cleaning
 
+# Guardado del dataframe
+# Pendiente de modificar a opciones mas robustas como una base de datos
+dataframes = {}
+
+# Autenticacion, pendiente de cambiar la logica
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+# Inicializacion de la API
 app = FastAPI()
 
-@app.post("/receive-dataset/")
-async def receive_dataset(request: Request):
+
+# Logica para recibir el Dataframe
+@app.post("/receive-dataset/{user_id}")
+async def receive_dataset(request: Request, user_id: str = Depends(oauth2_scheme)):
     buf = await request.body()
     table = pa.ipc.deserialize_table(buf)
     df = table.to_pandas()
 
-    # Devuelve mensaje de confirmación, falta añadir la logica para procesar el dataframe
-    return {"mensaje": "DataFrame recibido y procesado."}
+    # Guardamos el DataFrame usando el user_id como clave
+    dataframes[user_id] = df
+
+    return {"mensaje": "DataFrame recibido y almacenado."}
+
+@app.post("/clean-dataset/{user_id}")
+async def clean_dataset(options: dict, user_id: str = Depends(oauth2_scheme)):
+    if user_id not in dataframes:
+        raise HTTPException(status_code=404, detail="DataFrame no encontrado, carga un dataframe antes")
+    
+    df = dataframes[user_id]
+
+    # Aplica la función de limpieza según las opciones recibidas
+    # Las opciones estan configuradas en data_cleaning_functions.py
+    
+    result = data_cleaning(df, options)
+
+    # Actualiza el DataFrame limpio en la "base de datos"
+    dataframes[user_id] = df
+
+    # Pendiente de modificar el return segun sea necesario
+    return {"mensaje": f"Proceso de {options} completado", "resultado": result}


### PR DESCRIPTION
Contiene la logica de la API para recibir el dataframe desde dataset_loading y guardarlo (esta logica hay que cambiarla), comprueba la autenticacion (Esta logica hay que cambiarla), y tiene la logica para limpiar el dataset. Los endpoints son: /receive-dataset/{user-id} y /clean-dataset/{user-id}. Las opciones le entran por Query parameters